### PR TITLE
Fixes Custom Color Display

### DIFF
--- a/app/src/components/Colors.tsx
+++ b/app/src/components/Colors.tsx
@@ -26,7 +26,7 @@ export const Colors = ({ data }: { data: ClassnameInfo[] }) => {
       </h2>
       <div className='flex flex-wrap gap-5 px-4'>
         {colors.map(color => <div key={color} className='flex flex-col items-center'>
-          <div className={`w-16 h-16 rounded border ${color.replace('text', 'bg')}`}>&nbsp;</div>
+          <div className={`w-16 h-16 rounded border ${color.replaceAll('\\', '').replace('text', 'bg')}`}>&nbsp;</div>
           <p>{color.replaceAll('\\', '')}</p>
         </div>)}
       </div>


### PR DESCRIPTION
Currently the classes are not properly applied to the elements meant to display the colors due to the extra `/` characters. This applies the same transformation to that classname. 